### PR TITLE
feat(app):clear history search

### DIFF
--- a/packages/app/src/components/Search.tsx
+++ b/packages/app/src/components/Search.tsx
@@ -265,7 +265,7 @@ export default function Search() {
                       {h}
                     </div>
                     <button
-                      className="i-close text-base-500 hover:text-base-900"
+                      className="i-carbon-close text-base-500 hover:text-base-900"
                       onMouseDown={() => onClearHistory(index)}
                     />
                   </div>

--- a/packages/app/src/components/Search.tsx
+++ b/packages/app/src/components/Search.tsx
@@ -244,7 +244,7 @@ export default function Search() {
             heading={
               <div className="flex justify-between w-full">
                 <div>搜索历史</div>
-                <button className="text-link" onClick={onClearHistories}>
+                <button className="text-link" onMouseDown={onClearHistories}>
                   清空
                 </button>
               </div>
@@ -266,7 +266,7 @@ export default function Search() {
                     </div>
                     <button
                       className="i-close text-base-500 hover:text-base-900"
-                      onClick={() => onClearHistory(index)}
+                      onMouseDown={() => onClearHistory(index)}
                     />
                   </div>
                 }

--- a/packages/app/src/components/Search.tsx
+++ b/packages/app/src/components/Search.tsx
@@ -142,6 +142,16 @@ export default function Search() {
     };
   }, []);
 
+  const onClearHistories = () => {
+    const emptyHistories: string[] = [];
+    histories.set(emptyHistories);
+  };
+
+  const onClearHistory = (index: number) => {
+    const filterHistories = histories.get().filter((_, _index) => _index != index);
+    histories.set(filterHistories);
+  };
+
   return (
     <Command
       id="animegarden-search"
@@ -230,19 +240,36 @@ export default function Search() {
           </>
         )}
         {enable && history.length > 0 && (
-          <Command.Group heading="搜索历史">
-            {history.map((h) => (
-              <Command.Item
-                key={h}
-                value={h}
-                onMouseDown={() => {
-                  selectGoToSearch(h);
-                }}
-                onSelect={() => {
-                  onInputChange(h);
-                }}
-              >
-                {h}
+          <Command.Group
+            heading={
+              <div className="flex justify-between w-full">
+                <div>搜索历史</div>
+                <button className="text-link" onClick={onClearHistories}>
+                  清空
+                </button>
+              </div>
+            }
+          >
+            {history.map((h, index) => (
+              <Command.Item key={h}>
+                {
+                  <div className="flex justify-between w-full">
+                    <div
+                      onMouseDown={() => {
+                        selectGoToSearch(h);
+                      }}
+                      onSelect={() => {
+                        onInputChange(h);
+                      }}
+                    >
+                      {h}
+                    </div>
+                    <button
+                      className="i-close text-base-500 hover:text-base-900"
+                      onClick={() => onClearHistory(index)}
+                    />
+                  </div>
+                }
               </Command.Item>
             ))}
           </Command.Group>

--- a/packages/app/src/layouts/Layout.astro
+++ b/packages/app/src/layouts/Layout.astro
@@ -261,18 +261,6 @@ function followSearch(params: Record<string, string>) {
         --at-apply: text-sky-700 hover:text-sky-500;
       }
 
-      .i-close {
-        --un-icon: url("data:image/svg+xml;utf8,%3Csvg viewBox='0 0 32 32' width='1.2em' height='1.2em' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill='currentColor' d='M24 9.4L22.6 8L16 14.6L9.4 8L8 9.4l6.6 6.6L8 22.6L9.4 24l6.6-6.6l6.6 6.6l1.4-1.4l-6.6-6.6L24 9.4z'/%3E%3C/svg%3E");
-        -webkit-mask: var(--un-icon) no-repeat;
-        mask: var(--un-icon) no-repeat;
-        -webkit-mask-size: 100% 100%;
-        mask-size: 100% 100%;
-        background-color: currentColor;
-        color: inherit;
-        width: 1.2em;
-        height: 1.2em;
-      }
-
       .text-link-active {
         /* prettier-ignore */
         --at-apply: hover:text-sky-600;

--- a/packages/app/src/layouts/Layout.astro
+++ b/packages/app/src/layouts/Layout.astro
@@ -25,7 +25,7 @@ const enableFeed = page === '1' && !Astro.url.pathname.startsWith('/resource/');
 
 const env = getRuntimeEnv(Astro.locals);
 const timestamp =
-  Astro.props.timestamp ?? new Date((await env.animegarden.get('state/refresh-timestamp')) ?? 0);
+  Astro.props.timestamp ?? new Date((await env?.animegarden.get('state/refresh-timestamp')) ?? new Date());
 
 const hasFansubSearch = search.has('fansubId');
 
@@ -259,6 +259,18 @@ function followSearch(params: Record<string, string>) {
       .text-link {
         /* prettier-ignore */
         --at-apply: text-sky-700 hover:text-sky-500;
+      }
+
+      .i-close {
+        --un-icon: url("data:image/svg+xml;utf8,%3Csvg viewBox='0 0 32 32' width='1.2em' height='1.2em' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill='currentColor' d='M24 9.4L22.6 8L16 14.6L9.4 8L8 9.4l6.6 6.6L8 22.6L9.4 24l6.6-6.6l6.6 6.6l1.4-1.4l-6.6-6.6L24 9.4z'/%3E%3C/svg%3E");
+        -webkit-mask: var(--un-icon) no-repeat;
+        mask: var(--un-icon) no-repeat;
+        -webkit-mask-size: 100% 100%;
+        mask-size: 100% 100%;
+        background-color: currentColor;
+        color: inherit;
+        width: 1.2em;
+        height: 1.2em;
       }
 
       .text-link-active {


### PR DESCRIPTION
### Description

- [x] add `"清空" button` to clear all search history
- [x] add `close icon` to clear click item history

### Linked Issues

#401 

### Additional context

* `packages\app\src\components\Search.tsx` Line 268
className为`i-carbon-close`不知道为什么不生效,`i-carbon-download或rss`可以

* `packages\app\src\layouts\Layout.astro` Line 264
在这里手动加了叫做`i-close`的class,里面复制了`i-carbon-close`的样式,搞清楚为什么`i-carbon-close`没效果后可以去掉